### PR TITLE
Release Open IP Scanner 1.0.0

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34
         with:
           subject-path: release/*.deb
-          sbom-path: ${{ runner.temp }}/open-ip-scanner-provenance/*.spdx.json
+          sbom-path: ${{ runner.temp }}/open-ip-scanner-provenance/open-ip-scanner_1.0.0_amd64.spdx.json
       - name: Upload verified installable package
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,15 @@ These rules extend the workspace-level agent instructions and apply to the entir
 - After a successful required review, automatically create an intentional commit containing only the verified task scope and push the task branch to its upstream remote. No separate prompt is required for that commit or push.
 - Never merge a task branch into `main` until a human has verified the branch and explicitly authorized the merge. A successful automated review, push, or CI run is not human verification and does not authorize merging.
 - Pushing a task branch does not authorize opening a pull request, tagging a release, publishing packages, or merging.
+- Release evidence must describe the exact committed tree that produced it. If
+  packaged or source-archived files change after a release gate, rerun that gate
+  from the new clean commit before treating it as the candidate. Record the
+  final commit identity and post-commit result in the pull request, release
+  record, or ignored `.agent/test-results/` file; do not create a tracked
+  evidence-only commit that would invalidate the evidence it records.
+- Post-commit release validation is not an adversarial review. If it fails,
+  make the correction on the same version branch, repeat the applicable
+  pre-commit validation and review rules, then validate the new exact commit.
+- A release tag and its GitHub release must identify the same commit whose
+  release workflow produced the published package, checksum material, SBOM,
+  and attestations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented in this file.
 
+## [1.0.0] - 2026-07-15
+
+### Added
+
+- Deliver bounded, accuracy-scaled IPv4 discovery with stable progressive
+  results, source-aware hostname enrichment, truthful service evidence,
+  privacy-preserving diagnostics, and reproducible Debian packaging.
+- Publish the supported Linux x86-64 release with checksums, an SPDX SBOM, and
+  keyless GitHub build and SBOM attestations.
+
+### Changed
+
+- Complete the documented production-readiness, accessibility, platform,
+  security, support, and release-candidate gates for the first stable release.
+
 ## [0.7.9] - 2026-07-15
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.28)
-project(OpenIpScanner VERSION 0.7.9 LANGUAGES CXX)
+project(OpenIpScanner VERSION 1.0.0 LANGUAGES CXX)
 
 include(cmake/Hardening.cmake)
 

--- a/docs/data-provenance.md
+++ b/docs/data-provenance.md
@@ -44,7 +44,9 @@ binding, and x86-64 control-flow protection. Configure-time checks reject a
 toolchain that cannot apply the required stack-clash and hardening flags.
 
 The same gate creates a deterministic source archive, `SHA256SUMS`, and an
-SPDX 2.3 JSON document. The SBOM identifies the Debian package by SHA-256 and
+SPDX 2.3 JSON document. `SHA256SUMS` covers the Debian package, source archive,
+and SPDX document even though CI uploads the installable package separately.
+The SBOM identifies the Debian package by SHA-256 and
 lists every installed regular file with SHA-1 and SHA-256 checksums. License
 fields remain `NOASSERTION` where one expression cannot truthfully cover the
 application, IEEE-derived vendor data, and external runtime components.

--- a/docs/execplans/1.0-production-readiness-implementation.md
+++ b/docs/execplans/1.0-production-readiness-implementation.md
@@ -60,7 +60,8 @@ The visible demonstration is a controlled scan fixture that publishes `fixture.l
 - [x] (2026-07-15) Completed the locally automatable ARTIFACT-PROVENANCE increment as version `0.7.3`: checked Release flags require PIE, stack/fortify/clash/control-flow protection, full RELRO, and immediate binding; two isolated 39-test builds produce byte-identical Debian packages; and the audited package yields a deterministic source archive, SHA-256 manifest, and SPDX 2.3 installed-file inventory. A dormant clean-`1.0.0` workflow uses commit-pinned GitHub OIDC actions for build and SBOM attestations. Actual RC attestation and independent verification remain explicitly deferred operations, so the roadmap item stays open.
 - [x] (2026-07-15) Completed BUILD-OUTPUT-HYGIENE as version `0.7.7`: compilation, quality, reproducibility, CPack staging, and provenance validation use disposable `build/` scratch, while `release/` is the persistent installable-package destination with one canonical filename per version. Same-version rebuilds atomically overwrite only that filename; other human-controlled releases are ignored. Documentation identifies `build/dev/open-ip-scanner` as the stable validation binary. Approximately 4 GB of legacy output and all duplicate package/staging remnants were purged. Two isolated Release builds passed 39/39 each, reproducibility, metadata, Lintian, package lifecycle, hardening, bundle, external checksum, cleanup, and focused policy checks passed, and the final fresh scoped adversarial review found no actionable issue.
 - [x] (2026-07-15) Completed UI-CLEANUP as version `0.7.8`: clickable service pills expose a hit-tested pointing-hand cursor; Help and About share the external-link launcher; scan status is limited to state, progress, host count, and Accuracy mode; Settings prefers 720 by 520 while every page fits horizontally at its 600-by-440 minimum; and Details keeps service evidence inline while restoring its last visible height. Focused UI contracts pass, as do metadata lint, normal and strict 39/39, ASan/UBSan 38/38, and ThreadSanitizer 37/37. The first review's fixture-mode snapshot finding was repaired, and the final fresh adversarial review found no actionable issue. Human feedback then identified collapsed Appearance selectors, clipped and inconsistently aligned Performance labels, and an undesirable About redesign. The final candidate retains the compact icon-led About layout with actionable links and directly tests all three corrections. The repaired candidate again passes the full gate, renewed fresh adversarial review found no actionable issue, and human verification passed.
-- [ ] (2026-07-15) Continued RELEASE-CANDIDATE-PREPARATION as version `0.7.9`: the active no-bypass default-branch ruleset and the owner's passing Kubuntu 26.04 qualification close QUALITY-GATE, PLATFORM-SUPPORT, and ACCESSIBILITY. Documentation now locates the large-scan upper bound in pre-scan confirmation and treats 600 by 440 as the resizable Settings minimum. The complete current-content release gate passes normal and strict 39/39, ASan/UBSan 38/38, ThreadSanitizer 37/37, zero-warning Lintian, install/remove, hardening, two byte-identical packages, and external source/checksum/SPDX validation. Fresh review found only two documentation-claim corrections, now applied. The same release gate passes from clean candidate commit `e4a53cd`; PR/main checks and the separately authorized `1.0.0` attestation run remain.
+- [x] (2026-07-15) Completed RELEASE-CANDIDATE-PREPARATION as version `0.7.9`: the active no-bypass default-branch ruleset and the owner's passing Kubuntu 26.04 qualification close QUALITY-GATE, PLATFORM-SUPPORT, and ACCESSIBILITY. The complete gate passed locally and on the protected pull request before merge; main validation is the final pre-1.0 CI confirmation.
+- [ ] (2026-07-15) Preparing the authorized `1.0.0` candidate: codify exact-final-commit release evidence, reconcile the final changelog and roadmap, validate and review the branch, obtain remote build/SBOM attestations, merge through protected main, and publish only artifacts produced from the tagged commit.
 - [x] Milestone 1: establish the modular build, characterization tests, quality commands, and supported platform contract.
 - [x] Milestone 2: extract and correct target parsing, settings, CSV export, and vendor-data handling.
 - [x] Milestone 3: replace the blocking scan implementation with an immutable, cancellable, budgeted scan session.
@@ -138,6 +139,22 @@ The visible demonstration is a controlled scan fixture that publishes `fixture.l
   tool's architecture-agnostic aggregate status.
 
 ## Decision Log
+
+- Decision: Promote the completed candidate to `1.0.0` and automate the GitHub
+  release, while requiring the published tag and artifacts to share one exact
+  validated commit.
+  Rationale: The owner judged the review comment a procedural evidence gap,
+  explicitly authorized version 1.0 and a GitHub release, and requested that
+  the corrected exact-commit procedure become repository policy.
+  Date/Author: 2026-07-15 / User and Codex
+
+- Decision: Create the GitHub Release only after the existing `v1.0.0` tag has
+  completed the release-artifact workflow, then attach the independently
+  verified files from that exact run with `gh release create --verify-tag`.
+  Rationale: The workflow intentionally produces and attests artifacts but does
+  not publish a Release. This sequence prevents implicit tag creation and keeps
+  the tag, workflow identity, attestations, and published downloads identical.
+  Date/Author: 2026-07-15 / Codex
 
 - Decision: Search an open-only service by its observed port, but not by the catalog's probable service name until protocol verification succeeds.
   Rationale: The port is direct device evidence. Treating a catalog guess as searchable service identity would contradict the concise `Unknown:<port>` presentation and the existing evidence policy; verified labels and IDs remain searchable.
@@ -518,7 +535,11 @@ ARTIFACT-PROVENANCE is accepted when hardening inspection meets the defined base
 
 ACCESSIBILITY is accepted when Qt 6.4 and 6.8 offscreen startup is warning-free, automated accessibility inspection finds names/roles for all controls, and the manual smoke passes light, dark, high-contrast, 200% scaling, and keyboard-only use. SEARCH-ENRICHMENT is accepted when every normalized identity/evidence field—including alternate full hostnames omitted from table cells—participates in filtering without resetting order, selection, or viewport state. SERVICE-PILL-THEMING is accepted when verified services have distinct palette-aware colors, unknown ports remain neutral, representative light/dark/high-contrast/selected/disabled palettes meet the documented contrast threshold, and geometry remains stable. RELEASE-DOCS is accepted when a clean-machine operator can build/install, authorize a scan, understand traffic/privacy, troubleshoot mDNS, export diagnostics, uninstall, verify artifacts, and follow the release checklist without reading source code.
 
-The 1.0 source version may be set only after SCAN-CONFIGURATION through RELEASE-DOCS satisfy these conditions and appear in the roadmap's Completed section. This plan does not authorize a release tag or publication.
+The 1.0 source version may be set after SCAN-CONFIGURATION through RELEASE-DOCS
+satisfy these conditions, only the 1.0-only remote attestation remains, and the
+owner explicitly authorizes promotion. Publication remains blocked until the
+exact candidate commit has verifiable remote build and SBOM attestations. The
+owner authorized the `1.0.0` tag and automated GitHub release on 2026-07-15.
 
 ## Idempotence and Recovery
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -94,8 +94,10 @@ Create and push `v1.0.0` at the already merged, clean candidate commit; do not
 allow a release command to create or move the tag implicitly. Wait for that
 tag's `Release artifacts` run to pass. In a new empty verification directory,
 download `open-ip-scanner-1.0.0` and
-`open-ip-scanner-1.0.0-verification` from that run. Verify `SHA256SUMS`, the
-package and SPDX attestations, and the package's SPDX predicate against
+`open-ip-scanner-1.0.0-verification` from that run into that same directory so
+the complete `SHA256SUMS` can verify the separately uploaded package together
+with the source archive and SPDX document. Verify the package and SPDX
+attestations, and the package's SPDX predicate, against
 `calculatetech/open-ip-scanner`.
 
 Only after those checks pass, create the GitHub Release with

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,9 +1,9 @@
 # Release-candidate checklist
 
-This checklist prepares and verifies a release candidate. It does not authorize
-a tag, GitHub release, package publication, branch-protection change, or version
-`1.0.0`. Those are explicit human decisions after all required roadmap items
-and final smoke evidence are complete.
+This checklist prepares and verifies a release candidate. The owner authorized
+version `1.0.0` and an automated GitHub release on 2026-07-15. Publication still
+requires the exact tagged commit to pass every remaining automated provenance
+and verification item below.
 
 ## Source and scope
 
@@ -12,8 +12,8 @@ and final smoke evidence are complete.
 - [x] `docs/`, README, Help, About, AppStream, package text, and changelog agree
   on behavior, support boundaries, privacy, and known limitations.
 - [x] The version agrees in CMake-generated application, package, manual page,
-  AppStream, changelog, and About output. Keep the major version at `0` until
-  the owner approves the final 1.0 candidate.
+  AppStream, changelog, and About output. The owner approved the final 1.0
+  candidate before the version changed to `1.0.0`.
 - [ ] The candidate commit is on a reviewed branch, the worktree is clean, and
   main has only the intended fast-forwarded commits.
 - [x] Default-branch protection and required checks are configured at the
@@ -21,7 +21,8 @@ and final smoke evidence are complete.
 
 ## Automated validation
 
-- [x] `./scripts/quality-gate.sh release` passes from a clean checkout.
+- [ ] `./scripts/quality-gate.sh release` passes from the exact clean candidate
+  commit.
 - [ ] Main CI passes the Ubuntu 24.04 compatibility-floor gate, Debian 13 newer
   gate, isolated mDNS responder, and downstream tested-package job.
 - [x] Strict project warnings, metadata lint, ASan/UBSan, ThreadSanitizer's
@@ -58,7 +59,7 @@ complete Kubuntu 26.04 checklist passed without exception.
 
 ## Artifacts and provenance
 
-- [x] Produce one Debian package, source archive, SHA-256 checksum file, and
+- [ ] Produce one Debian package, source archive, SHA-256 checksum file, and
   SPDX JSON SBOM from the clean candidate commit.
 - [ ] Generate keyless GitHub build-provenance and SBOM attestations with the
   least required OIDC permissions and the immutable candidate commit identity.
@@ -66,20 +67,41 @@ complete Kubuntu 26.04 checklist passed without exception.
   file against `calculatetech/open-ip-scanner` from a separate clean
   environment. Confirm that the package also has the SPDX document as its SBOM
   attestation predicate.
+- [ ] Create the GitHub Release only after the exact `v1.0.0` tag workflow
+  passes, and attach only the files downloaded from that successful run.
 - [x] Confirm artifact names, versions, architecture, license/notices, manual
   page, support documents, dependencies, and retention policy.
 
-Local 0.7.9 evidence from clean candidate commit `e4a53cd`: the release gate
-passed normal and strict 39/39,
+Pre-1.0 candidate evidence: the release gate passed normal and strict 39/39,
 ASan/UBSan 38/38, ThreadSanitizer 37/37, zero-warning Lintian, package
 install/remove, hardening, two byte-identical package builds, source/checksum/
 SPDX validation, and external checksum verification. The installable candidate
-is `release/open-ip-scanner_0.7.9_amd64.deb`.
+was `release/open-ip-scanner_0.7.9_amd64.deb`. Exact-commit 1.0 evidence belongs
+in the pull request, release record, and ignored test-result record so recording
+it cannot change the packaged candidate after validation.
 
 ## Human release decision
 
-- [ ] Review remaining known limitations and post-1.0 roadmap items.
-- [ ] Review security contact readiness and the private-reporting path.
-- [ ] Obtain final human product/accessibility approval.
-- [ ] Only then authorize `1.0.0`, tag creation, release notes, GitHub release,
+- [x] Review remaining known limitations and post-1.0 roadmap items.
+- [x] Review security contact readiness and the private-reporting path.
+- [x] Obtain final human product/accessibility approval.
+- [x] Only then authorize `1.0.0`, tag creation, release notes, GitHub release,
   and package publication as separate actions.
+
+## Exact-tag publication procedure
+
+Create and push `v1.0.0` at the already merged, clean candidate commit; do not
+allow a release command to create or move the tag implicitly. Wait for that
+tag's `Release artifacts` run to pass. In a new empty verification directory,
+download `open-ip-scanner-1.0.0` and
+`open-ip-scanner-1.0.0-verification` from that run. Verify `SHA256SUMS`, the
+package and SPDX attestations, and the package's SPDX predicate against
+`calculatetech/open-ip-scanner`.
+
+Only after those checks pass, create the GitHub Release with
+`gh release create v1.0.0 --verify-tag` and attach the downloaded Debian
+package, source archive, checksum file, and SPDX JSON file. This makes the
+published tag, attestations, and downloadable files refer to one immutable
+commit and prevents `gh release create` from silently creating an unvalidated
+tag. Record the workflow URL and verification result in the release notes or
+other external release record, not in a new tracked evidence commit.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 This file is the single source of truth for unfinished product, engineering, documentation, and release work. Detailed evidence for why each 1.0 item exists is in [the production-readiness audit](production-readiness-audit.md). New ideas belong here rather than in a second backlog.
 
-The audited baseline is `0.2.0` at commit `91e0a7a`; cumulative application behavior through `0.7.8` is human-verified, including the complete Kubuntu 26.04 desktop checklist. Version 1.0 is not yet authorized. Every unchecked item under “Required for 1.0” is a release gate; the post-1.0 section is explicitly outside the first production release.
+The audited baseline is `0.2.0` at commit `91e0a7a`; cumulative application behavior through `0.7.9` is human-verified, including the complete Kubuntu 26.04 desktop checklist. The owner authorized the `1.0.0` candidate and automated GitHub release on 2026-07-15. Every unchecked item under “Required for 1.0” is a release gate; the post-1.0 section is explicitly outside the first production release.
 
 ## Delivered implementation increments
 
@@ -401,9 +401,9 @@ Priority matches the most severe audit finding an item closes. All items in the 
     ThreadSanitizer 37/37, zero-warning Lintian, install/remove, hardening, and
     two byte-identical packages. The externally staged source archive,
     SHA-256 manifest, and SPDX inventory independently validate. The same gate
-    also passes from clean candidate commit `e4a53cd`. GitHub OIDC attestations
-    and their independent verification remain gated to the separately
-    authorized final `1.0.0` candidate.
+    also passed from the clean committed 0.7.9 candidate. GitHub OIDC
+    attestations and their independent verification remained gated to the
+    separately authorized final `1.0.0` candidate.
   - Done when hardening inspection meets the documented baseline, two clean builds produce matching artifacts after normalization, and users can verify signed checksums and provenance.
 
 #### PREFIX-SAFETY
@@ -517,7 +517,7 @@ Priority matches the most severe audit finding an item closes. All items in the 
 
 #### RELEASE-DOCS
 
-- [ ] **Complete the 1.0 release documentation and support contract.** `Medium`
+- [x] **Complete the 1.0 release documentation and support contract.** `Medium`
   - Reconcile README, Help, About, changelog, package metadata, and actual behavior. Document mDNS troubleshooting, scan limitations, permissions, privacy, data provenance, support channels, security-reporting process, compatibility, upgrade/migration behavior, and known limitations.
   - Add a 1.0 release checklist that consumes the automated gates, updates every version source, creates signed artifacts, and records validation evidence.
   - Current progress on `0.7.2`: the canonical user guide, support process,
@@ -537,7 +537,12 @@ Priority matches the most severe audit finding an item closes. All items in the 
     evidence are reconciled, Settings is correctly described as resizable from
     a 600-by-440 minimum, and the large-scan upper bound is correctly located
     in pre-scan confirmation rather than the concise status bar. The final
-    `1.0.0` changelog/version reconciliation remains separately authorized.
+    `1.0.0` changelog/version reconciliation remained separately authorized.
+  - Completed for `1.0.0`: the owner authorized the stable candidate and
+    automated GitHub release, the final changelog now reconciles the cumulative
+    product, support, platform, and provenance contract, and the checklist
+    requires exact-tag workflow success and independent verification before
+    attaching those same artifacts with `gh release create --verify-tag`.
   - Done when a clean-machine installation and operator runbook can be followed without repository knowledge, all claims have a passing test or explicit limitation, and the 1.0 changelog is complete.
 
 ## Post-1.0

--- a/scripts/build-release-artifact.sh
+++ b/scripts/build-release-artifact.sh
@@ -192,14 +192,8 @@ main() {
         cmake -E copy \
             "$bundle_dir/open-ip-scanner-$version.tar.gz" \
             "$bundle_dir/open-ip-scanner_${version}_amd64.spdx.json" \
+            "$bundle_dir/SHA256SUMS" \
             "$provenance_dir/"
-        (
-            cd "$provenance_dir"
-            sha256sum \
-                "open-ip-scanner-$version.tar.gz" \
-                "open-ip-scanner_${version}_amd64.spdx.json" \
-                > SHA256SUMS
-        )
     fi
 
     stage_release_package "$package"

--- a/tests/qualitygatepolicy_test.py
+++ b/tests/qualitygatepolicy_test.py
@@ -501,12 +501,14 @@ def main() -> int:
             "verification material must remain separate from installable packages")
     require("prepare_provenance_directory" in artifact_commands,
             "release builder must validate and own its provenance destination")
-    require(any('"open-ip-scanner-$version.tar.gz"' in command
+    require(any('"$bundle_dir/open-ip-scanner-$version.tar.gz"' in command
                 for command in artifact_commands) and
-            any('"open-ip-scanner_${version}_amd64.spdx.json"' in command
+            any('"$bundle_dir/open-ip-scanner_${version}_amd64.spdx.json"' in command
                 for command in artifact_commands) and
-            any("> SHA256SUMS" in command for command in artifact_commands),
-            "verification material must carry checksums for its own contents")
+            any('"$bundle_dir/SHA256SUMS"' in command
+                for command in artifact_commands) and
+            not any("> SHA256SUMS" in command for command in artifact_commands),
+            "verification material must preserve the complete bundle checksums")
 
     presets = json.loads((ROOT / "CMakePresets.json").read_text(encoding="utf-8"))
     preset_directories = {

--- a/tests/qualitygatepolicy_test.py
+++ b/tests/qualitygatepolicy_test.py
@@ -490,7 +490,8 @@ def main() -> int:
             "release/*.deb",
             "SBOM subject must use the exact canonical package path")
     require(sbom_attestation.get("with", {}).get("sbom-path") ==
-            "${{ runner.temp }}/open-ip-scanner-provenance/*.spdx.json",
+            "${{ runner.temp }}/open-ip-scanner-provenance/"
+            "open-ip-scanner_1.0.0_amd64.spdx.json",
             "SBOM attestation must use the exact canonical SPDX path")
     package_upload = step_with(release_job, "name", "Upload verified installable package")
     require(package_upload.get("with", {}).get("path") == "release/*.deb",


### PR DESCRIPTION
## Summary

- promote the human-verified release candidate to 1.0.0
- codify exact-final-commit release evidence and tag identity rules
- complete the 1.0 changelog, roadmap, and exact-tag publication procedure

## Validation

- local pre-commit release gate passed all quality, sanitizer, packaging, reproducibility, Lintian, lifecycle, hardening, checksum, and SPDX checks
- fresh read-only adversarial review completed; its publication-procedure finding is addressed
- exact-commit local and GitHub provenance validation are running against commit 5284120

The GitHub Release will be created only after the merged exact tag workflow passes and those same artifacts are independently verified.